### PR TITLE
feat: добавлена поддержка не-ASCII имён файлов в multipart (RFC 5987)

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -43,8 +43,17 @@ export type MultipartBodyConfig = {
   key: string;
   /** Текстовое значение поля */
   textValue?: string;
-  /** Имя файла */
+  /**
+   * Имя файла. Если содержит не-ASCII символы, используйте вместе с `encodedFileName`.
+   * В этом случае `fileName` должно быть ASCII-совместимым fallback-именем.
+   */
   fileName?: string;
+  /**
+   * URL-encoded имя файла (результат `encodeURIComponent`) для поддержки RFC 5987.
+   * Когда присутствует, runtime строит: `filename="{fileName}"; filename*=UTF-8''{encodedFileName}`
+   * Используйте хелпер `encodeFilename()` для автоматического заполнения обоих полей.
+   */
+  encodedFileName?: string;
   /** Содержимое файла в виде ArrayBuffer */
   fileValue?: ArrayBuffer;
   /** MIME-тип файла */

--- a/lib/utils/encodeFilename.ts
+++ b/lib/utils/encodeFilename.ts
@@ -1,0 +1,49 @@
+import type { MultipartBodyConfig } from "../common";
+
+/**
+ * Подготавливает поля `fileName` и `encodedFileName` для `MultipartBodyConfig`
+ * с поддержкой не-ASCII символов (RFC 5987).
+ *
+ * Если имя файла содержит только ASCII — возвращает только `fileName`.
+ * Если содержит не-ASCII (кириллица, спецсимволы и т.д.) — возвращает оба поля:
+ * - `fileName`: ASCII-совместимый fallback
+ * - `encodedFileName`: URL-encoded оригинальное имя для `filename*=UTF-8''...`
+ *
+ * @param fileName - Оригинальное имя файла (может содержать любые символы)
+ * @param asciiFallback - ASCII-имя для серверов без RFC 5987. По умолчанию — `"file"`
+ *   с сохранением расширения оригинального файла.
+ *
+ * @example
+ * ```typescript
+ * multipartBody: [{
+ *   key: "file",
+ *   ...encodeFilename("Печать полиса.pdf"),
+ *   // → { fileName: "file.pdf", encodedFileName: "%D0%9F%D0%B5%D1%87%D0%B0%D1%82%D1%8C%20%D0%BF%D0%BE%D0%BB%D0%B8%D1%81%D0%B0.pdf" }
+ *   fileValue: fileContent,
+ *   contentType: "application/octet-stream",
+ * }]
+ * ```
+ */
+export function encodeFilename(
+  fileName: string,
+  asciiFallback?: string
+): Pick<MultipartBodyConfig, "fileName" | "encodedFileName"> {
+  const hasNonAscii = /[^\x20-\x7E]/.test(fileName);
+
+  if (!hasNonAscii) {
+    return { fileName };
+  }
+
+  const fallback = asciiFallback ?? buildAsciiFallback(fileName);
+
+  return {
+    fileName: fallback,
+    encodedFileName: encodeURIComponent(fileName),
+  };
+}
+
+function buildAsciiFallback(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf(".");
+  const ext = dotIndex !== -1 ? fileName.slice(dotIndex) : "";
+  return `file${ext}`;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./api";
+export * from "./encodeFilename";


### PR DESCRIPTION
Добавлено поле encodedFileName в MultipartBodyConfig и хелпер encodeFilename() для формирования filename*=UTF-8'' согласно RFC 5987. Для ASCII-имён возвращается только fileName, для не-ASCII — пара ASCII-fallback + URL-encoded оригинал.